### PR TITLE
Issue #11 fix: Hide lobby/char select until logged in. 

### DIFF
--- a/src/client/app/colyseus.lobby.service.ts
+++ b/src/client/app/colyseus.lobby.service.ts
@@ -13,7 +13,7 @@ export class ColyseusLobbyService {
   client: any;
   colyseus: any;
   lobbyState: LobbyState = new LobbyState({});
-  myAccount: Account = new Account({});
+  myAccount: Account = null;
   myCharacter: any = { name: '' };
 
   constructor(private auth: AuthService) {}
@@ -135,6 +135,7 @@ export class ColyseusLobbyService {
   private logout() {
     this.auth.logout();
     this.client.send({ action: 'logout' });
+    this.myAccount = null;
 
     window.location.reload();
   }


### PR DESCRIPTION
Account object validation fixed. Object was used to check null state when hiding windows. Object was created before log-in and not destroyed after log-out resulting in object never being null. Removed instantiation on class construction and killed object reference on signout invocation. Object instantiation is done outside of class and Account reference is passed with setAccount(account) on line 97.

TEST PERFORMED:
- Before logging in, hidden.
- After logging in, not hidden.
- After logging out, hidden.
- Switching Users, successfully logged in.
- New User Creation, successfully created & logged in.
- Browser closure & opening w/ logging in, successfully logged in.